### PR TITLE
Promote vLINK to prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vesper-metadata",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Vesper metadata",
   "keywords": [
     "addresses",

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -21,7 +21,7 @@
       "birthblock": 12201459,
       "chainId": 1,
       "riskLevel": 3,
-      "stage": "beta"
+      "stage": "alpha"
     },
     {
       "name": "vLINK",

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -85,7 +85,6 @@
       "birthblock": 11475256,
       "chainId": 1,
       "riskLevel": 3,
-      "supersededBy": "0xB1C0d6EFD3bAb0FC3CA648a12C15d0827e3bcde5",
       "stage": "prod"
     },
     {

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Vesper metadata",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "controllers": [
     {
       "name": "collateralManager",

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -30,7 +30,7 @@
       "birthblock": 12144811,
       "chainId": 1,
       "riskLevel": 3,
-      "stage": "beta"
+      "stage": "prod"
     },
     {
       "name": "vVSP",


### PR DESCRIPTION
vLINK will be promoted to prod on Apr 29th. 

This PR also demotes vUSDC 2.1 as it is not ready for beta yet.