### PR TITLE
Set vUSDC migration path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vesper-metadata",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Vesper metadata",
   "keywords": [
     "addresses",

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -95,6 +95,7 @@
       "birthblock": 11475256,
       "chainId": 1,
       "riskLevel": 3,
+      "supersededBy": "0x777A7850251b7A301cfA1E7b1d8a9c4a9C49Cf85",
       "stage": "prod"
     },
     {

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -63,7 +63,7 @@
     },
     {
       "name": "vBetaUSDC",
-      "address": "0x1e86044468b92c310800d4b350e0f83387a7097f",
+      "address": "0x1e86044468b92c310800d4B350E0F83387a7097F",
       "asset": "USDC",
       "birthblock": 11607534,
       "chainId": 1,

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Vesper metadata",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "controllers": [
     {
       "name": "collateralManager",

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -15,6 +15,26 @@
   ],
   "pools": [
     {
+      "name": "vUSDT",
+      "address": "0x95c0b30C6276e67Ae95127aF458573a63113BdFF",
+      "asset": "USDT",
+      "birthblock": 12525156,
+      "chainId": 1,
+      "riskLevel": 3,
+      "stage": "alpha",
+      "version": 3
+    },
+    {
+      "name": "vUNI",
+      "address": "0xf858a354AD255D21e17C56f8F2b10Ed67dfb40aE",
+      "asset": "UNI",
+      "birthblock": 12520468,
+      "chainId": 1,
+      "riskLevel": 3,
+      "stage": "alpha",
+      "version": 3
+    },
+    {
       "name": "vUSDC-v3",
       "address": "0x777A7850251b7A301cfA1E7b1d8a9c4a9C49Cf85",
       "asset": "USDC",


### PR DESCRIPTION
This PR sets the migration path of vUSDC to vUSDC-v3.

It also fixes the format of vBetaUSDC address (was all lowercase instead of checksum) and adds vUNI and vUSDT to the alpha stage.