### PR TITLE
Add MiniArmyKnife contract address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vesper-metadata",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Vesper metadata",
   "keywords": [
     "addresses",

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -183,5 +183,12 @@
       "decimals": 18,
       "chainId": 1
     }
+  ],
+  "support": [
+    {
+      "name": "MiniArmyKnife",
+      "address": "0x5d72A9f081990219C97aF877e0e79EADaEaFCa80",
+      "chainId": 1
+    }
   ]
 }

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Vesper metadata",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "controllers": [
     {
       "name": "collateralManager",


### PR DESCRIPTION
Adds the address of the `MiniArmyKnife` to the Vesper metadata file.