### PR TITLE
Update MAK address and remove vUSDVC v3 update path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vesper-metadata",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Vesper metadata",
   "keywords": [
     "addresses",

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -146,7 +146,6 @@
       "birthblock": 11475256,
       "chainId": 1,
       "riskLevel": 3,
-      "supersededBy": "0x777A7850251b7A301cfA1E7b1d8a9c4a9C49Cf85",
       "stage": "prod",
       "symbol": "vUSDC",
       "decimals": 18,

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Vesper metadata",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "controllers": [
     {
       "name": "collateralManager",

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -239,7 +239,7 @@
   "support": [
     {
       "name": "MiniArmyKnife",
-      "address": "0x5d72A9f081990219C97aF877e0e79EADaEaFCa80",
+      "address": "0xda5E6D9c7103ABfA8866cc96bB75A7aB15368B2D",
       "chainId": 1
     }
   ]


### PR DESCRIPTION
This is needed to complete the migration of vUSDC pools.