### PR TITLE
Update synth contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vesper-metadata",
-  "version": "2.72.0",
+  "version": "2.73.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vesper-metadata",
-  "version": "2.72.0",
+  "version": "2.73.0",
   "description": "Vesper metadata",
   "keywords": [
     "addresses",

--- a/src/vesper-metadata.json
+++ b/src/vesper-metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Vesper metadata",
-  "version": "2.72.0",
+  "version": "2.73.0",
   "controllers": [
     {
       "name": "collateralManager",


### PR DESCRIPTION
This PR changes the address for the synth controller to match the latest deployed contract. (see https://github.com/bloqpriv/vesper-monorepo/issues/3024).

It also upgrates pools vaAPE, vaMUSD, vaLINK, vaUSDC, vaALUSD, vaDPI, vaFEI and vaDAI to version 5

### Metrics

<!--
Add the actual effort spent working in this PR. Use hours or days as appropriate.
-->

Actual effort: 1h
